### PR TITLE
2.6 が終わり

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ version = "0.1.0"
 name = "c02_mandelbrot"
 version = "0.1.0"
 dependencies = [
+ "crossbeam",
  "image",
  "num",
 ]
@@ -486,6 +487,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +523,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/c02_mandelbrot/Cargo.toml
+++ b/c02_mandelbrot/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 num = "0.4.3"
 image = "0.25.5"
+crossbeam = "0.8.4"

--- a/c02_mandelbrot/src/main.rs
+++ b/c02_mandelbrot/src/main.rs
@@ -22,7 +22,26 @@ fn main() {
     let lower_right = parse_complex(&args[4]).expect("error parsing lower right corner point");
 
     let mut pixels = vec![0; bounds.0 * bounds.1];
-    render(&mut pixels, bounds, upper_left, lower_right);
+    let threads = 8;
+    let ros_per_band = bounds.1 / threads + 1;
+    {
+        let bands: Vec<&mut [u8]> = pixels.chunks_mut(ros_per_band * bounds.0).collect();
+        crossbeam::scope(|spawner| {
+            for (i, band) in bands.into_iter().enumerate() {
+                let top = i * ros_per_band;
+                let height = band.len() / bounds.0;
+                let band_bounds = (bounds.0, height);
+                let band_upper_left = pixel_to_point(bounds, (0, top), upper_left, lower_right);
+                let band_lower_right =
+                    pixel_to_point(bounds, (bounds.0, top + height), upper_left, lower_right);
+
+                spawner.spawn(move |_| {
+                    render(band, band_bounds, band_upper_left, band_lower_right);
+                });
+            }
+        })
+        .unwrap();
+    }
     write_image(&args[1], &pixels, bounds).expect("error writing PNG file");
 }
 

--- a/c02_mandelbrot/src/main.rs
+++ b/c02_mandelbrot/src/main.rs
@@ -1,12 +1,29 @@
 use image::codecs::png::PngEncoder;
 use image::{ExtendedColorType, ImageEncoder};
 use num::Complex;
+use std::env;
 use std::error::Error;
 use std::fs::File;
 use std::str::FromStr;
 
 fn main() {
-    println!("Hello, world!");
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 5 {
+        eprintln!("Usage: {} FILE PIXELS UPPER_LEFT LOWER_RIGHT", args[0]);
+        eprintln!(
+            "Example: {} mandel.png 1000x750 -1.20,0.35 -1,0.20",
+            args[0]
+        );
+        std::process::exit(1);
+    }
+
+    let bounds = parse_pair(&args[2], 'x').expect("error parsing image dimensions");
+    let upper_left = parse_complex(&args[3]).expect("error parsing upper left corner point");
+    let lower_right = parse_complex(&args[4]).expect("error parsing lower right corner point");
+
+    let mut pixels = vec![0; bounds.0 * bounds.1];
+    render(&mut pixels, bounds, upper_left, lower_right);
+    write_image(&args[1], &pixels, bounds).expect("error writing PNG file");
 }
 
 #[allow(dead_code)]
@@ -17,7 +34,6 @@ fn complex_square_add_loop(c: Complex<f64>) {
     }
 }
 
-#[allow(dead_code)]
 fn escape_time(c: Complex<f64>, limit: usize) -> Option<usize> {
     let mut z = Complex { re: 0.0, im: 0.0 };
     for i in 0..limit {
@@ -29,7 +45,6 @@ fn escape_time(c: Complex<f64>, limit: usize) -> Option<usize> {
     None
 }
 
-#[allow(dead_code)]
 fn parse_pair<T: FromStr>(s: &str, separator: char) -> Option<(T, T)> {
     match s.find(separator) {
         None => None,
@@ -51,7 +66,6 @@ fn test_parse_pair() {
     assert_eq!(parse_pair::<f64>("0.5x1.5", 'x'), Some((0.5, 1.5)));
 }
 
-#[allow(dead_code)]
 fn parse_complex(s: &str) -> Option<Complex<f64>> {
     match parse_pair::<f64>(s, ',') {
         None => None,
@@ -71,7 +85,6 @@ fn test_parse_complex() {
     assert_eq!(parse_complex(",-0.0625"), None);
 }
 
-#[allow(dead_code)]
 fn pixel_to_point(
     bounds: (usize, usize),
     pixel: (usize, usize),
@@ -104,7 +117,6 @@ fn test_pixel_to_point() {
     );
 }
 
-#[allow(dead_code)]
 fn render(
     pixels: &mut [u8],
     bounds: (usize, usize),
@@ -123,7 +135,6 @@ fn render(
     }
 }
 
-#[allow(dead_code)]
 fn write_image(
     filename: &str,
     pixels: &[u8],


### PR DESCRIPTION
マンデルブロ集合を書き出すプログラムを作成した
マシン性能の差か、本に書かれた値だと 2秒程度しかかからなかったので、大きめにした

```shell
# 並列化前
$ time ../target/release/c02_mandelbrot mandel.png 16000x12000 -1.20,0.35 -1,0.20
../target/release/c02_mandelbrot mandel.png 16000x12000 -1.20,0.35 -1,0.20  31.70s user 0.12s system 99% cpu 31.828 total
```

```shell
# 並列化後
$ time ../target/release/c02_mandelbrot mandel.png 16000x12000 -1.20,0.35 -1,0.20
../target/release/c02_mandelbrot mandel.png 16000x12000 -1.20,0.35 -1,0.20  36.88s user 0.11s system 342% cpu 10.788 total
```