### PR TITLE
4.3 コピー型、4.4 Rc & Arc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc-arc"
+version = "0.1.0"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "copy-type"
+version = "0.1.0"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ members = [
     "c02/quickreplace",
     "c03/example",
     "c04/ownership",
-    "c04/os-move", "c04/copy-type",
+    "c04/os-move",
+    "c04/copy-type",
+    "c04/rc-arc",
 ]
 resolver = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "c02/quickreplace",
     "c03/example",
     "c04/ownership",
-    "c04/os-move",
+    "c04/os-move", "c04/copy-type",
 ]
 resolver = "3"
 

--- a/c04/copy-type/Cargo.toml
+++ b/c04/copy-type/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "copy-type"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]

--- a/c04/copy-type/src/main.rs
+++ b/c04/copy-type/src/main.rs
@@ -1,0 +1,31 @@
+// For 4.3
+fn main() {
+    let string1 = "somnabulance".to_string();
+    let string2 = string1;
+
+    let num1: i32 = 36;
+    let num2 = num1;
+
+    // println!("string1: {}", string1); // error[E0382]: borrow of moved value: `string1`
+    println!("string2: {}", string2);
+    println!("num1: {}", num1);
+    println!("num2: {}", num2);
+
+    let l = Label { number: 3 };
+    print(l);
+    println!("My number is: {}", l.number);
+}
+#[derive(Clone, Copy)]
+struct Label {
+    number: u32,
+}
+
+fn print(l: Label) {
+    println!("STAMP: {}", l.number);
+}
+
+// #[derive(Clone, Copy)]
+// struct StringLabel {
+//     number: String, // error[E0204]: the trait `Copy` cannot be implemented for this type
+// }
+

--- a/c04/rc-arc/Cargo.toml
+++ b/c04/rc-arc/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rc-arc"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]

--- a/c04/rc-arc/src/main.rs
+++ b/c04/rc-arc/src/main.rs
@@ -1,0 +1,14 @@
+use std::rc::Rc;
+
+// For 4.4
+fn main() {
+    let s = Rc::new("shirataki".to_string());
+    let t = s.clone();
+    let u = s.clone();
+
+    assert!(s.contains("shira"));
+    assert_eq!(t.find("taki"), Some(5));
+    println!("{} are quite chewy, almost bouncy, but lack flavor", u);
+
+    // s.push_str(" noodles"); // error[E0596]: cannot borrow data in an `Rc` as mutable
+}


### PR DESCRIPTION
- 4.3
    - コピー型は移動が行われない
    - いわゆるプリミティブな型は基本的にコピー型
    - プリミティブな値だけで構成される構造体や列挙型もコピー型にできるが、自動的にはならない
- 4.4
    - 参照カウントも作れる
    - RCとARCの違いはスレッドセーフかどうか
    - 基本的に不変なので、参照カウントループは作れないが、構造体の内部可変と組み合わせると作れる