### PR TITLE
13章が終わり

### DIFF
--- a/c13/example/src/main.rs
+++ b/c13/example/src/main.rs
@@ -145,4 +145,38 @@ fn main() {
     println!("{:?}", dot_zshrc);
 
     // 13.8 Borrow BorrowMut
+    // 13.9 From Into
+    use std::net::Ipv4Addr;
+    fn ping<A>(address: A) -> std::io::Result<bool>
+    where
+        A: Into<Ipv4Addr>,
+    {
+        let ipv4_address = address.into();
+        println!("Pinging {}...", ipv4_address);
+        Ok(true)
+    }
+
+    ping(Ipv4Addr::new(127, 0, 0, 1)).unwrap();
+    ping([8, 8, 8, 8]).unwrap();
+    ping(0xd076eb94_u32).unwrap();
+
+    let addr1 = Ipv4Addr::from([127, 0, 0, 1]);
+    let addr2 = Ipv4Addr::from(0xd076eb94_u32);
+    println!("addr1: {:?}", addr1);
+    println!("addr2: {:?}", addr2);
+
+    let text = "Beautiful Soup".to_string();
+    let bytes: Vec<u8> = text.into();
+    println!("bytes: {:?}", bytes);
+
+    type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
+    type GenericResult<T> = Result<T, GenericError>;
+    #[allow(dead_code)]
+    fn parse_i32_bytes(b: &[u8]) -> GenericResult<i32> {
+        Ok(std::str::from_utf8(b)?.parse::<i32>()?)
+    }
+    
+    let huge = 2_000_000_000_000_i64;
+    let smaller = huge as i32;
+    println!("{} as i32: {}", huge, smaller);
 }

--- a/c13/example/src/main.rs
+++ b/c13/example/src/main.rs
@@ -175,8 +175,18 @@ fn main() {
     fn parse_i32_bytes(b: &[u8]) -> GenericResult<i32> {
         Ok(std::str::from_utf8(b)?.parse::<i32>()?)
     }
-    
+
     let huge = 2_000_000_000_000_i64;
     let smaller = huge as i32;
     println!("{} as i32: {}", huge, smaller);
+
+    // 13.10 TryFrom TryInto
+    let smaller = huge.try_into().unwrap_or(i32::MAX);
+    println!("{} as i32: {}", huge, smaller);
+
+    let minus_huge = -huge;
+    let smaller = minus_huge
+        .try_into()
+        .unwrap_or_else(|_| if minus_huge >= 0 { i32::MAX } else { i32::MIN });
+    println!("{} as i32: {}", minus_huge, smaller);
 }

--- a/c13/example/src/main.rs
+++ b/c13/example/src/main.rs
@@ -1,4 +1,5 @@
 use rand::random;
+use std::path::Path;
 
 fn main() {
     println!("Chapter 13");
@@ -189,4 +190,33 @@ fn main() {
         .try_into()
         .unwrap_or_else(|_| if minus_huge >= 0 { i32::MAX } else { i32::MIN });
     println!("{} as i32: {}", minus_huge, smaller);
+
+    // 13.11 ToOwned
+    // 13.12 Cow (Clone On Write)
+    #[allow(dead_code)]
+    enum MyError {
+        OutOfMemory,
+        StackOverflow,
+        MachineOnFire,
+        Unfathomable,
+        FileNotFound { path: Box<Path> },
+    }
+
+    use std::borrow::Cow;
+    fn describe(error: &MyError) -> Cow<'static, str> {
+        match *error {
+            MyError::OutOfMemory => "out of memory".into(),
+            MyError::StackOverflow => "stack overflow".into(),
+            MyError::MachineOnFire => "machine on fire".into(),
+            MyError::Unfathomable => "unfathomable".into(),
+            MyError::FileNotFound { ref path } => {
+                format!("file not found: {}", path.display()).into()
+            }
+        }
+    }
+    let mut log = Vec::new();
+    let error = MyError::OutOfMemory;
+    log.push(describe(&error).into_owned());
+    
+    println!("{:?}", log);
 }


### PR DESCRIPTION
型の変換に使うものに関するお話

- From, Into 失敗しない変換。Fromを実装するとIntoはついてくる
- TryFrom, TryInto 失敗する変換。これもTryFromを実装するだけでいい
- Cow 借用か所有か判断できない場合に、直前まで保留できるという機構
   - 固定の文字列を返すのか、動的に生成するのかが実行時まで分からない状況に使用する