### PR TITLE
Transcribe 17.4.1

### DIFF
--- a/c17/example/src/s04_format_output.rs
+++ b/c17/example/src/s04_format_output.rs
@@ -19,4 +19,18 @@ pub fn run() {
         msb = 42
     );
     assert_eq!(format!("{{a, c}} ⊂ {{a, b, c}}"), "{a, c} ⊂ {a, b, c}");
+    
+    println!("17.4.1 formatting text");
+    let bookend = "bookend";
+    println!("{}", bookend);
+    println!("{:4}", bookend);
+    println!("{:.12}", bookend);
+    println!("{:12.20}", bookend);
+    println!("{:^12}", bookend);
+    println!("{:>12.20}", bookend);
+    println!("{:=^12}", bookend);
+    println!("{:*>12.4}", bookend);
+    
+    assert_eq!(format!("{:4}", "th\u{e9}"), "th\u{e9} ");
+    assert_eq!(format!("{:4}", "th\u{301}"), "th\u{301} ");
 }


### PR DESCRIPTION
```rust
assert_eq!(format!("{:4}", "th\u{301}"), "th\u{301} ");
```

これがきちんとパディングされるようになっている
2024からの変更っぽい